### PR TITLE
Fix regression on MP where network settings page doesn't show up

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4779,7 +4779,7 @@ void GuiMenu::openNetworkSettings_batocera(bool selectWifiEnable)
 		bool internalWifiDisabled = SystemConf::getInstance()->getBool("wifi.internal.disabled");
 		auto disableInternalWifi = std::make_shared<SwitchComponent>(mWindow);
 		disableInternalWifi->setState(internalWifiDisabled);
-		s->addWithDescription(_("DISABLE INTERNAL WIFI"),"Turns off internal WiFi adapter.  Allows external wifi adapters", disableInternalWifi);
+		s->addWithDescription(_("DISABLE INTERNAL WIFI"),"Turns off internal WiFi adapter.  Allows external WiFi adapters", disableInternalWifi);
 
 		disableInternalWifi->setOnChangedCallback([this, disableInternalWifi, internalWifiDisabled]()
 		{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4771,7 +4771,7 @@ void GuiMenu::openNetworkSettings_batocera(bool selectWifiEnable)
 			openNetworkSettings_batocera(true);
 		}
 	});
-#ifdef RG552 || RG351P || RG351V
+#if defined(RG552) || defined(RG351P) || defined(RG351V)
 	if (baseWifiEnabled)
 	{
 		s->addGroup(_("ADVANCED WIFI SETTINGS"));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4789,8 +4789,8 @@ void GuiMenu::openNetworkSettings_batocera(bool selectWifiEnable)
 			runSystemCommand("/usr/bin/batocera-internal-wifi "+interalWifiDisableString, "", nullptr);
 		});
 	}
-	mWindow->pushGui(s);
 #endif
+	mWindow->pushGui(s);
 }
 
 void GuiMenu::openQuitMenu_batocera()


### PR DESCRIPTION
This was caused by the internal wifi PR - my bad: https://github.com/AmberELEC/emulationstation/pull/52

- Also - realize was only taking effect on the 552 - need to use `#if` and not `#ifdef`